### PR TITLE
Fix backwards apostrophe

### DIFF
--- a/index.html
+++ b/index.html
@@ -2640,7 +2640,7 @@
             ‘Minsky moment’<sup class="footNote" id="fn31">31</sup> ‘is another matter, for the products themselves were
             never the source of crisis; it was their governance, expressed in pricing models and the conditions of
             access to leverage they were built upon. It is not surprising, therefore, that the emergence of
-            ’crypto-derivatives’ and a focus on DeFi governance are emerging concurrently. Whether they are emerging
+            ‘crypto-derivatives’ and a focus on DeFi governance are emerging concurrently. Whether they are emerging
             compatibly remains to be seen.</p>
     </div>
     <div id="u103" class="unit available">


### PR DESCRIPTION
Changing ’crypto-derivatives’ to ‘crypto-derivatives’ (the first apostrophe was backwards)